### PR TITLE
refactor: Truck problem refactoring.. 

### DIFF
--- a/11-1.[Stack]truck_bridge.py
+++ b/11-1.[Stack]truck_bridge.py
@@ -11,6 +11,3 @@ def main(bridge_length, weight, truck_weights):
             else: # weight를 넘어버린 경우? 아무것도 안올라갔으니 
                 trucks_on_bridge.append(0)  # 리스트에 0 추가
     return time
-
-if __name__ == '__main__':
-    main(2, 10, [7,4,5,6])

--- a/11-1.[Stack]truck_bridge.py
+++ b/11-1.[Stack]truck_bridge.py
@@ -1,18 +1,17 @@
 def main(bridge_length, weight, truck_weights):
-    """Shows basic usage of the Drive v3 API.
-    Prints the names and ids of the first 10 files the user has access to.
-    """
     time = 0
     trucks_on_bridge = [0] * bridge_length  # 올라온 트럭을 담는 리스트
-    trucks_on_bridge = trucks_on_bridge.reverse()
 
-    while len(trucks_on_bridge):  # ex. trucks_on_bridge = [0,0]  bridge index 만큼
+    while len(trucks_on_bridge)>0: 
         time += 1
-        trucks_on_bridge.pop()  # bridge.pop(0)의 의미: bridge[index]에 트럭이 올라왔다고 가정
-        if truck_weights:
-            if sum(trucks_on_bridge)+truck_weights[0] <= weight:  # 올라가 있는 애들 + 남은 애들 중에 올라간애... 여기서 pop하면 안됨
+        trucks_on_bridge.pop(0) 
+
+        if(len(truck_weights)>0): # 자 이제 트럭을 올려보자
+            if sum(trucks_on_bridge)+truck_weights[0] <= weight: 
                 trucks_on_bridge.append(truck_weights.pop(0))
-        else:
-            trucks_on_bridge.append(0)  # 리스트에 0 추가
-    print(time)
+            else: # weight를 넘어버린 경우? 아무것도 안올라갔으니 
+                trucks_on_bridge.append(0)  # 리스트에 0 추가
     return time
+    
+if __name__ == '__main__':
+    main(2, 10, [7,4,5,6])

--- a/11-1.[Stack]truck_bridge.py
+++ b/11-1.[Stack]truck_bridge.py
@@ -5,13 +5,12 @@ def main(bridge_length, weight, truck_weights):
     while len(trucks_on_bridge)>0: 
         time += 1
         trucks_on_bridge.pop(0) 
-
         if(len(truck_weights)>0): # 자 이제 트럭을 올려보자
             if sum(trucks_on_bridge)+truck_weights[0] <= weight: 
                 trucks_on_bridge.append(truck_weights.pop(0))
             else: # weight를 넘어버린 경우? 아무것도 안올라갔으니 
                 trucks_on_bridge.append(0)  # 리스트에 0 추가
     return time
-    
+
 if __name__ == '__main__':
     main(2, 10, [7,4,5,6])


### PR DESCRIPTION
안됐던 이유
1. 맨 처음 내 코드 무한루프 돌았던 이유:
`while len(trucks_on_bridge)>0 : `아니고 `while len(trucks_on_bridge):` 로 해놔서 무한루프 돌아서 효율성 테스트 실패함

이런 어이업는... 

2. 두번째 세미나 때 다같이 작성한 코드 실패 이유:
```
def solution(bridge_length, weight, truck_weights):
    time = 0
    trucks_on_bridge = [0] * bridge_length  # 올라온 트럭을 담는 리스트

    trucks_on_bridge.reverse()

    while len(trucks_on_bridge)>0:  # ex. trucks_on_bridge = [0,0]  bridge index 만큼
        time += 1
        trucks_on_bridge.pop()  # bridge.pop(0)의 의미: bridge[index]에 트럭이 올라왔다고 가정

        if(len(truck_weights)>0):
            if sum(trucks_on_bridge)+truck_weights[0] <= weight:  # 올라가 있는 애들 + 남은 애들 중에 올라간애... 여기서 pop하면 안됨
                trucks_on_bridge.append(truck_weights.pop(0))
                print("if안", trucks_on_bridge)

            else:
                trucks_on_bridge.append(0)  # 리스트에 0 추가
                print("else안", trucks_on_bridge)
    print(time+bridge_length)
    return time+bridge_length
```
truck_on_bridge.reverse()를 루프 밖에서 하고, 루프 안에서 append(0)으로 첫번째 요소에다가 0을 추가함.

3. 해결: 첫번째 생각했던 코드의 어이없는 문제를 고치고 효율성 테스트도 통과.

